### PR TITLE
Add sort to search

### DIFF
--- a/src/commands/mcp-tools/search.ts
+++ b/src/commands/mcp-tools/search.ts
@@ -7,7 +7,7 @@ import { searchSlackMessages } from '../../services/slack-services';
 
 const queryDescription = `
 Search query with Slack search modifiers.
-Available modifiers: in:<channel/user>, from:<user>, has:<emoji reaction>, is:thread, during:YYYY-MM-DD, before:YYYY-MM-DD, after:YYYY-MM-DD, has:pin, with:<user>.
+Available modifiers: in:<channel/user>, from:<user>, has:<emoji reaction>, is:thread, before:YYYY-MM-DD, after:YYYY-MM-DD, has:pin, with:<user>.
 Identify users with "@me", "@display.name" or "<@U12345>".
 Identify channels with "#channel-name" or "<#C12345>".
 Exclude results with a dash (-) in front of the modifier.
@@ -24,6 +24,7 @@ const searchParams = z.object({
     .optional()
     .default(100)
     .describe('Maximum number of results to return (1-1000). Default is 100.'),
+  sort: z.string().describe("Timestamp sort order, can be `asc` or `desc`")
 });
 
 export const searchTool = tool({
@@ -36,9 +37,9 @@ export const searchTool = tool({
     readOnlyHint: true,
     title: 'Search Slack',
   },
-  execute: async ({ query, count }) => {
+  execute: async ({ query, count, sort }) => {
     const client = await createWebClient();
-    const messages = await searchSlackMessages(client, query, count);
+    const messages = await searchSlackMessages(client, query, count, sort);
     const cache = await getCacheForMessages(client, messages);
 
     return generateSearchResultsMarkdown(messages, cache);

--- a/src/commands/mcp-tools/thread-replies.ts
+++ b/src/commands/mcp-tools/thread-replies.ts
@@ -12,7 +12,7 @@ const threadRepliesParams = z.object({
   ts: z
     .string()
     .describe(
-      'Timestamp of the parent message in Unix epoch time format (e.g., "1234567890.123456")',
+      'Unique identifier of either a thread’s parent message or a message in the thread. ts must be the timestamp of an existing message with 0 or more replies. If there are no replies then just the single message referenced by ts will return - it is just an ordinary, unthreaded message. convert TS to the form 1234567890.123456',
     ),
   limit: z
     .number()

--- a/src/services/slack-services.ts
+++ b/src/services/slack-services.ts
@@ -143,7 +143,7 @@ export async function getSlackThreadReplies(channel: string, ts: string, limit?:
       limit,
     });
 
-    const messages = response.messages?.filter((msg) => msg.ts !== ts) || [];
+    const messages = response.messages || [];
     GlobalContext.log.debug('Found replies:', messages.length);
 
     // Convert conversation replies to a format compatible with entity cache
@@ -259,6 +259,7 @@ export async function searchSlackMessages(
   client: WebClient,
   query: string,
   count: number,
+  sort: 'asc' | 'desc'
 ): Promise<Match[]> {
   GlobalContext.log.debug(`Original search query: ${query}`);
 
@@ -268,7 +269,7 @@ export async function searchSlackMessages(
   const queryArgs: SearchMessagesArguments = {
     query: enhancedQuery,
     sort: 'timestamp',
-    sort_dir: 'asc',
+    sort_dir: sort,
     count: Math.min(100, count),
   };
 


### PR DESCRIPTION
* Removes duration from search tool description (looks inaccurate according to the Slack docs)
* Allows search to sort ascending or descending
* Removes filtering of current message from getting the thread replies
* Gives more explicit instruction for the thread replies timestamp