### PR TITLE
Fix macOS cookie extraction for App Store installs and Chromium 130+

### DIFF
--- a/src/auth/cookie-extractor.ts
+++ b/src/auth/cookie-extractor.ts
@@ -10,36 +10,69 @@ import { GlobalContext } from '../context';
 
 const exec = promisify(execCallback);
 
+const KEYCHAIN_ACCOUNTS = ['Slack App Store Key', 'Slack Key'] as const;
+
+interface SlackInstall {
+  cookiesPath: string;
+  keychainAccount: string;
+  variant: 'app-store' | 'direct-download';
+}
+
+const SLACK_INSTALLS: SlackInstall[] = [
+  {
+    cookiesPath: 'Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/Cookies',
+    keychainAccount: 'Slack App Store Key',
+    variant: 'app-store',
+  },
+  {
+    cookiesPath: 'Library/Application Support/Slack/Cookies',
+    keychainAccount: 'Slack Key',
+    variant: 'direct-download',
+  },
+];
+
 /**
- * Decrypt the cookie value with the encryption key
+ * Decrypt the cookie value with the encryption key.
+ * Handles Chromium 130+ format (cookies DB version >= 24) where a 32-byte
+ * SHA-256 hash of the host_key is prepended to the plaintext.
  */
-function decryptCookieValue(encryptedValue: Buffer, encryptionKey: Buffer): string {
+function decryptCookieValue(
+  encryptedValue: Buffer,
+  encryptionKey: Buffer,
+  hostKey?: string,
+): string {
   try {
-    // Check for 'v10' or 'v11' prefix
     const prefix = encryptedValue.slice(0, 3).toString();
     let ciphertext: Buffer;
 
     if (prefix === 'v10' || prefix === 'v11') {
-      // Remove the 3-byte prefix
       ciphertext = encryptedValue.slice(3);
     } else {
       throw new Error('Unsupported cookie version');
     }
 
-    // Python uses a fixed IV of 16 spaces
     const iv = Buffer.from(' '.repeat(16));
 
-    // Decrypt using AES-128-CBC
     const decipher = crypto.createDecipheriv('aes-128-cbc', encryptionKey, iv);
     const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
 
-    // Remove padding (PKCS#7 padding is handled automatically by crypto)
-    let endPos = decrypted.length;
-    while (endPos > 0 && decrypted[endPos - 1] === 0) {
+    let payload = decrypted;
+
+    // Chromium 130+ (cookies DB version >= 24) prepends SHA-256(host_key) to the plaintext
+    if (hostKey) {
+      const hostHash = crypto.createHash('sha256').update(hostKey).digest();
+      if (payload.length > 32 && payload.slice(0, 32).equals(hostHash)) {
+        GlobalContext.log.debug('Detected Chromium 130+ SHA-256 host_key prefix, stripping');
+        payload = payload.slice(32);
+      }
+    }
+
+    let endPos = payload.length;
+    while (endPos > 0 && payload[endPos - 1] === 0) {
       endPos--;
     }
 
-    const result = decrypted.slice(0, endPos).toString('utf8');
+    const result = payload.slice(0, endPos).toString('utf8');
     GlobalContext.log.debug(`Decrypted cookie value: ${result}`);
     return result;
   } catch (error) {
@@ -50,62 +83,81 @@ function decryptCookieValue(encryptedValue: Buffer, encryptionKey: Buffer): stri
 }
 
 /**
- * Get the encryption key from the macOS keychain
+ * Try to retrieve the Slack Safe Storage password from the macOS Keychain.
+ * Tries both "Slack App Store Key" and "Slack Key" account names, returning
+ * the first one that succeeds along with the account name used.
  */
-async function getEncryptionKey(): Promise<Buffer> {
-  try {
-    // Get the encryption key from the macOS keychain
-    // The keychain item name for Slack is "Slack App Store Key"
-    const { stdout } = await exec('security find-generic-password -wa "Slack App Store Key"');
-
-    // The key is hex-encoded, we need to convert it to a buffer
-    // But first, trim any whitespace
-    const key = stdout.trim();
-
-    // The key is used as-is for AES-128-CBC, but we need to derive a key using PBKDF2
-    // We use the same salt 'saltysalt' that Chrome uses
-    const salt = Buffer.from('saltysalt');
-    const keyLength = 16; // 128 bits for AES-128
-    const iterations = 1003;
-
-    GlobalContext.log.debug(`Found encryption key`);
-    return crypto.pbkdf2Sync(key, salt, iterations, keyLength, 'sha1');
-  } catch (error) {
-    throw new Error(
-      `Could not retrieve Slack encryption key from keychain: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+async function getEncryptionKeyForAccount(account: string): Promise<Buffer> {
+  const { stdout } = await exec(
+    `security find-generic-password -wa ${JSON.stringify(account)}`,
+  );
+  const key = stdout.trim();
+  const salt = Buffer.from('saltysalt');
+  return crypto.pbkdf2Sync(key, salt, 1003, 16, 'sha1');
 }
 
 /**
- * Get the path to the Slack cookies database file
+ * Detect the Slack installation variant and return the matching cookies path
+ * and encryption key. Tries each known install location paired with its
+ * corresponding Keychain account.
  */
-function getCookiesDbPath(): string {
-  const paths = [
-    join(homedir(), 'Library/Application Support/Slack/Cookies'),
-    join(
-      homedir(),
-      'Library/Containers/com.tinyspeck.slackmacgap/Data/Library/Application Support/Slack/Cookies',
-    ),
-  ];
+async function detectSlackInstall(): Promise<{ dbPath: string; encryptionKey: Buffer }> {
+  const errors: string[] = [];
 
-  for (const path of paths) {
-    if (existsSync(path)) {
-      GlobalContext.log.debug(`Using cookies database path: ${path}`);
-      return path;
+  for (const install of SLACK_INSTALLS) {
+    const fullPath = join(homedir(), install.cookiesPath);
+    if (!existsSync(fullPath)) {
+      continue;
+    }
+
+    try {
+      const encryptionKey = await getEncryptionKeyForAccount(install.keychainAccount);
+      GlobalContext.log.debug(
+        `Using ${install.variant} install: ${fullPath} with Keychain account "${install.keychainAccount}"`,
+      );
+      return { dbPath: fullPath, encryptionKey };
+    } catch (e) {
+      errors.push(
+        `${install.variant} (${install.keychainAccount}): ${e instanceof Error ? e.message : String(e)}`,
+      );
     }
   }
-  throw new Error("Could not find Slack's cookies database");
+
+  // Fallback: cookies file exists but the matching Keychain account was not found.
+  // Try every combination in case the user migrated between install types.
+  for (const install of SLACK_INSTALLS) {
+    const fullPath = join(homedir(), install.cookiesPath);
+    if (!existsSync(fullPath)) continue;
+
+    for (const account of KEYCHAIN_ACCOUNTS) {
+      if (account === install.keychainAccount) continue;
+      try {
+        const encryptionKey = await getEncryptionKeyForAccount(account);
+        GlobalContext.log.debug(
+          `Cross-matched: cookies from ${install.variant} with Keychain account "${account}"`,
+        );
+        return { dbPath: fullPath, encryptionKey };
+      } catch {
+        // not a match
+      }
+    }
+  }
+
+  throw new Error(
+    "Could not find a matching Slack cookies database and Keychain entry.\n" +
+      `Tried:\n  ${errors.join('\n  ')}\n` +
+      'Ensure Slack is installed and you have logged in at least once.',
+  );
 }
 
 /**
- * Extract and decrypt cookie value for Slack
- * This should only be used by the auth-from-app command
+ * Extract and decrypt cookie value for Slack.
+ * Automatically detects App Store vs direct-download installs and handles
+ * both classic and Chromium 130+ cookie encryption formats.
  */
 export async function fetchCookieFromApp(): Promise<string> {
   try {
-    const dbPath = getCookiesDbPath();
-    const encryptionKey = await getEncryptionKey();
+    const { dbPath, encryptionKey } = await detectSlackInstall();
 
     const db = await open({
       filename: dbPath,
@@ -115,7 +167,7 @@ export async function fetchCookieFromApp(): Promise<string> {
 
     try {
       const results = await db.all(
-        'SELECT name, encrypted_value FROM cookies WHERE name = "d" ORDER BY LENGTH(encrypted_value) DESC',
+        'SELECT host_key, name, encrypted_value FROM cookies WHERE name = "d" ORDER BY LENGTH(encrypted_value) DESC',
       );
 
       if (!results || results.length === 0 || !results[0].encrypted_value) {
@@ -128,7 +180,11 @@ export async function fetchCookieFromApp(): Promise<string> {
 
         for (const result of results) {
           try {
-            const decrypted = decryptCookieValue(result.encrypted_value, encryptionKey);
+            const decrypted = decryptCookieValue(
+              result.encrypted_value,
+              encryptionKey,
+              result.host_key,
+            );
             const xoxdIndex = decrypted.indexOf('xoxd-');
 
             if (xoxdIndex !== -1) {
@@ -151,7 +207,11 @@ export async function fetchCookieFromApp(): Promise<string> {
       const result = results[0];
       GlobalContext.log.debug('Found d= cookie');
 
-      const decryptedValue = decryptCookieValue(result.encrypted_value, encryptionKey);
+      const decryptedValue = decryptCookieValue(
+        result.encrypted_value,
+        encryptionKey,
+        result.host_key,
+      );
 
       const xoxdIndex = decryptedValue.indexOf('xoxd-');
       if (xoxdIndex !== -1) {

--- a/src/auth/cookie-extractor.ts
+++ b/src/auth/cookie-extractor.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { promisify } from 'node:util';
 import { exec as execCallback } from 'child_process';
-import { existsSync } from 'fs';
+import { existsSync, statSync } from 'fs';
 import Database from 'sqlite3';
 import { open } from 'sqlite';
 import crypto from 'crypto';
@@ -98,24 +98,36 @@ async function getEncryptionKeyForAccount(account: string): Promise<Buffer> {
 
 /**
  * Detect the Slack installation variant and return the matching cookies path
- * and encryption key. Tries each known install location paired with its
- * corresponding Keychain account.
+ * and encryption key. When multiple valid installations exist, the one with
+ * the most recently modified cookies file wins (i.e. the actively-used Slack).
  */
 async function detectSlackInstall(): Promise<{ dbPath: string; encryptionKey: Buffer }> {
+  interface Candidate {
+    dbPath: string;
+    encryptionKey: Buffer;
+    variant: string;
+    account: string;
+    mtime: number;
+  }
+
+  const candidates: Candidate[] = [];
   const errors: string[] = [];
 
+  // First pass: match each install path with its natural Keychain account.
   for (const install of SLACK_INSTALLS) {
     const fullPath = join(homedir(), install.cookiesPath);
-    if (!existsSync(fullPath)) {
-      continue;
-    }
+    if (!existsSync(fullPath)) continue;
 
     try {
       const encryptionKey = await getEncryptionKeyForAccount(install.keychainAccount);
-      GlobalContext.log.debug(
-        `Using ${install.variant} install: ${fullPath} with Keychain account "${install.keychainAccount}"`,
-      );
-      return { dbPath: fullPath, encryptionKey };
+      const mtime = statSync(fullPath).mtimeMs;
+      candidates.push({
+        dbPath: fullPath,
+        encryptionKey,
+        variant: install.variant,
+        account: install.keychainAccount,
+        mtime,
+      });
     } catch (e) {
       errors.push(
         `${install.variant} (${install.keychainAccount}): ${e instanceof Error ? e.message : String(e)}`,
@@ -123,31 +135,50 @@ async function detectSlackInstall(): Promise<{ dbPath: string; encryptionKey: Bu
     }
   }
 
-  // Fallback: cookies file exists but the matching Keychain account was not found.
-  // Try every combination in case the user migrated between install types.
-  for (const install of SLACK_INSTALLS) {
-    const fullPath = join(homedir(), install.cookiesPath);
-    if (!existsSync(fullPath)) continue;
+  // Second pass (fallback): try cross-matching in case the user migrated.
+  if (candidates.length === 0) {
+    for (const install of SLACK_INSTALLS) {
+      const fullPath = join(homedir(), install.cookiesPath);
+      if (!existsSync(fullPath)) continue;
 
-    for (const account of KEYCHAIN_ACCOUNTS) {
-      if (account === install.keychainAccount) continue;
-      try {
-        const encryptionKey = await getEncryptionKeyForAccount(account);
-        GlobalContext.log.debug(
-          `Cross-matched: cookies from ${install.variant} with Keychain account "${account}"`,
-        );
-        return { dbPath: fullPath, encryptionKey };
-      } catch {
-        // not a match
+      for (const account of KEYCHAIN_ACCOUNTS) {
+        if (account === install.keychainAccount) continue;
+        try {
+          const encryptionKey = await getEncryptionKeyForAccount(account);
+          const mtime = statSync(fullPath).mtimeMs;
+          candidates.push({
+            dbPath: fullPath,
+            encryptionKey,
+            variant: `${install.variant} (cross-matched)`,
+            account,
+            mtime,
+          });
+        } catch {
+          // not a match
+        }
       }
     }
   }
 
-  throw new Error(
-    "Could not find a matching Slack cookies database and Keychain entry.\n" +
-      `Tried:\n  ${errors.join('\n  ')}\n` +
-      'Ensure Slack is installed and you have logged in at least once.',
+  if (candidates.length === 0) {
+    throw new Error(
+      "Could not find a matching Slack cookies database and Keychain entry.\n" +
+        `Tried:\n  ${errors.join('\n  ')}\n` +
+        'Ensure Slack is installed and you have logged in at least once.',
+    );
+  }
+
+  // Prefer the most recently modified cookies file.
+  candidates.sort((a, b) => b.mtime - a.mtime);
+  const winner = candidates[0];
+
+  GlobalContext.log.debug(
+    `Using ${winner.variant} install: ${winner.dbPath} ` +
+      `(modified ${new Date(winner.mtime).toISOString()}) ` +
+      `with Keychain account "${winner.account}"`,
   );
+
+  return { dbPath: winner.dbPath, encryptionKey: winner.encryptionKey };
 }
 
 /**

--- a/src/auth/token-extractor.ts
+++ b/src/auth/token-extractor.ts
@@ -2,10 +2,13 @@ import { Level } from 'level';
 import { join } from 'node:path';
 import { homedir, platform } from 'node:os';
 import { GlobalContext } from '../context';
-import { existsSync } from 'node:fs';
+import { existsSync, statSync } from 'node:fs';
 
 /**
- * Gets the path to Slack's LevelDB
+ * Gets the path to Slack's LevelDB.
+ * When multiple paths exist (e.g. App Store container and direct download),
+ * the most recently modified one is preferred so stale data from old
+ * installations is not used.
  */
 function getLevelDBPath(): string {
   if (platform() !== 'darwin') {
@@ -20,15 +23,19 @@ function getLevelDBPath(): string {
     join(homedir(), 'Library/Application Support/Slack/Local Storage/leveldb'),
   ];
 
-  // Return the first path that exists
-  for (const path of paths) {
-    if (existsSync(path)) {
-      GlobalContext.log.debug(`Found leveldb path: ${path}`);
-      return path;
-    }
+  const existing = paths
+    .filter((p) => existsSync(p))
+    .map((p) => ({ path: p, mtime: statSync(p).mtimeMs }))
+    .sort((a, b) => b.mtime - a.mtime);
+
+  if (existing.length === 0) {
+    throw new Error("Could not find Slack's Local Storage directory");
   }
 
-  throw new Error("Could not find Slack's Local Storage directory");
+  GlobalContext.log.debug(
+    `Found ${existing.length} leveldb path(s), using most recent: ${existing[0].path}`,
+  );
+  return existing[0].path;
 }
 
 export interface WorkspaceInfo {


### PR DESCRIPTION
## Summary

- Fix `auth-from-app` failing with `bad decrypt` on macOS when using the Mac App Store version of Slack
- Support both App Store (`Slack App Store Key`) and direct-download (`Slack Key`) Keychain accounts
- Handle Chromium 130+ cookie encryption format (cookies DB `meta.version >= 24`) where a 32-byte SHA-256 hash of `host_key` is prepended to the plaintext

## Root cause

On machines where both `~/Library/Application Support/Slack/Cookies` (direct download) and `~/Library/Containers/com.tinyspeck.slackmacgap/.../Cookies` (App Store) exist, `getCookiesDbPath()` always picked the direct-download path first. However, the Keychain entry belonged to the App Store version (`Slack App Store Key`), so decryption used the wrong key for the wrong cookies file.

Additionally, the decryption function did not account for Chromium 130+ (Electron 33+) which prepends a SHA-256 hash of the `host_key` to the cookie plaintext before encryption.

## Changes

- Replace `getCookiesDbPath()` and `getEncryptionKey()` with `detectSlackInstall()`, which pairs each known cookies path with its correct Keychain account
- Add cross-matching fallback for users who migrated between install variants
- Add optional `hostKey` parameter to `decryptCookieValue()` to detect and strip the Chromium 130+ SHA-256 prefix
- Select `host_key` in the SQL query to pass to decryption

## Test plan

- [x] Tested on macOS with App Store Slack (previously failing, now works)
- [ ] Verify direct-download Slack still works (no access to test, but code path is preserved)
- [ ] Verify on machines with only one Slack variant installed


Made with [Cursor](https://cursor.com)